### PR TITLE
Fix dynamic lib finding logic

### DIFF
--- a/macho/input-files.cc
+++ b/macho/input-files.cc
@@ -1207,7 +1207,7 @@ template <typename E>
 static MappedFile<Context<E>> *
 find_external_lib(Context<E> &ctx, DylibFile<E> &loader, std::string path) {
   auto find = [&](std::string path) -> MappedFile<Context<E>> * {
-    if (!path.starts_with('/'))
+    if (path.starts_with('/'))
       return MappedFile<Context<E>>::open(ctx, path);
 
     for (const std::string &root : ctx.arg.syslibroot) {


### PR DESCRIPTION
The `path.starts_with('/')` check was inverted.