### PR TITLE
Add support for ios_min_version

### DIFF
--- a/macho/cmdline.cc
+++ b/macho/cmdline.cc
@@ -87,6 +87,8 @@ Options:
   -l<LIB>                     Search for a given library
   -lto_library <FILE>         Load a LTO linker plugin library
   -macos_version_min <VERSION>
+  -ios_version_min <VERSION>
+  -iphoneos_version_min <VERSION>
   -map <FILE>                 Write map file to a given file
   -mark_dead_strippable_dylib Mark the output as dead-strippable
   -needed-l<LIB>              Search for a given library
@@ -452,6 +454,10 @@ std::vector<std::string> parse_nonpositional_args(Context<E> &ctx) {
     } else if (read_arg("-macos_version_min")) {
       ctx.arg.platform = PLATFORM_MACOS;
       ctx.arg.platform_min_version = parse_version(ctx, arg);
+    } else if (read_arg("-iphoneos_version_min") || read_arg("-ios_version_min")) {
+      ctx.arg.platform = PLATFORM_IOS;
+      ctx.arg.platform_min_version = parse_version(ctx, arg);
+      ctx.arg.platform_sdk_version = ctx.arg.platform_min_version;
     } else if (read_joined("-hidden-l")) {
       remaining.push_back("-hidden-l");
       remaining.push_back(std::string(arg));

--- a/test/macho/ios-version-min.sh
+++ b/test/macho/ios-version-min.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+. $(dirname $0)/ios.inc
+
+cat <<EOF | $CC -o $t/a.o -c -xc -
+int main() {}
+EOF
+
+$CC --ld-path=./ld64 --target=$ARCH-apple-ios -o $t/exe1 $t/a.o -mios-version-min=11.2
+otool -l $t/exe1 > $t/log
+grep -q 'platform 2' $t/log
+grep -q 'minos 11.2' $t/log

--- a/test/macho/ios.inc
+++ b/test/macho/ios.inc
@@ -1,0 +1,43 @@
+# -*- mode: sh -*-
+
+# Make sure all commands print out messages in English
+export LC_ALL=C
+
+if [ "$ARCH" = "x86_64" ]; then
+    exit 0
+fi
+
+CC="xcrun --sdk iphoneos cc --target=${ARCH}-apple-ios"
+CXX="xcrun --sdk iphoneos c++ --target=${ARCH}-apple-ios"
+
+# Common functions
+test_cflags() {
+  echo 'int main() {}' | $CC "$@" -o /dev/null -xc - >& /dev/null
+}
+
+skip() {
+  echo skipped
+  trap - EXIT
+  exit 0
+}
+
+on_error() {
+  code=$?
+  echo "command failed: $1: $BASH_COMMAND"
+  trap - EXIT
+  exit $code
+}
+
+on_exit() {
+  echo OK
+  exit 0
+}
+
+trap 'on_error $LINENO' ERR
+trap on_exit EXIT
+
+# Print out the startup message
+testname=$(basename "$0" .sh)
+echo -n "Testing $testname ... "
+t=out/test/macho/$ARCH/$testname
+mkdir -p $t


### PR DESCRIPTION
Whenever passing `-mios-version-min` to (Apple) Clang, that gets passed on to ld64 as `-ios_version_min`, and I believe prior to iOS 10, it was `-iphoneos_version_min`. I don't see any real reason not to support both.
I know that this is technically already supported thru `-platform_version`, but more support surely is more better? :)