### PR TITLE
Support legacy TBD format

### DIFF
--- a/test/macho/tbd_legacy.sh
+++ b/test/macho/tbd_legacy.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+. $(dirname $0)/common.inc
+
+mkdir -p $t/libs/SomeFramework.framework/
+
+cat > $t/libs/SomeFramework.framework/SomeFramework.tbd <<EOF
+--- !tapi-tbd-v2
+archs:         [ x86_64-macos, arm64-macos ]
+uuids: ["x86_64-macos: 00000000-0000-0000-0000-000000000000", 
+        "arm64-macos: 00000000-0000-0000-0000-000000000000"]
+install-name:    '/usr/frameworks/SomeFramework.framework/SomeFramework'
+current-version: 0000
+compatibility-version: 150
+exports:
+  - archs:         [ x86_64-macos, arm64-macos ]
+    symbols:         [ _foo ]
+    weak-symbols:    [ _bar ]
+...
+EOF
+
+cat <<EOF | $CC -o $t/a.o -c -xc -
+extern void foo();
+extern void bar() __attribute__((weak_import));
+
+int main() {
+  foo();
+  if (bar)
+    bar();
+}
+EOF
+
+$CC --ld-path=./ld64 -o $t/exe $t/a.o -F$t/libs/ -Wl,-framework,SomeFramework
+
+otool -L $t/exe | grep -q '/usr/frameworks/SomeFramework.framework/SomeFramework'


### PR DESCRIPTION
The [legacy tbd format](https://github.com/apple-oss-distributions/tapi/blob/879172f75e43d14127d403d9de2066379b5e6173/docs/TBD_legacy.rst) has some differences from the [latest one](https://github.com/apple-oss-distributions/tapi/blob/879172f75e43d14127d403d9de2066379b5e6173/docs/TBD_current.rst).
Since sold specifically doesn't use a third party YAML parser and only implements necessary parts, I decided not to add logic for parsing tags (even though it's not too much overhead), and instead added a simple fallback for *one* of the important differences. The goal was just to make [libobjc](https://github.com/xybp888/iOS-SDKs/blob/master/iPhoneOS11.2.sdk/usr/lib/libobjc.A.tbd) get properly linked on iOS SDK 11.2, this is probably a moot point for the latest versions.