### PR TITLE
Add -no_warn_duplicate_libraries and -dead_strip to ignored flags

### DIFF
--- a/macho/cmdline.cc
+++ b/macho/cmdline.cc
@@ -574,6 +574,8 @@ std::vector<std::string> parse_nonpositional_args(Context<E> &ctx) {
       ctx.arg.x = true;
     } else if (read_flag("--no-call-graph-profile-sort")) {
     } else if (read_flag("--icf=none")) {
+    } else if (read_flag("-no_warn_duplicate_libraries")) {
+    } else if (read_flag("-dead_strip")) {
     } else {
       if (args[i][0] == '-')
         Fatal(ctx) << "unknown command line option: " << args[i];


### PR DESCRIPTION
This is an attempt to work around the issue described in #53.

> `mold: fatal: unknown command line option: -no_warn_duplicate_libraries`
> `mold: fatal: unknown command line option: -Wl,-dead_strip`


As my first attempt, I changed the `Fatal(ctx)` invocation in `macho/main.cc`'s parameter parsing code to `Warn(ctx)` and made sure that the Qt moc application linked successfully. 

Then I noticed how easy it is to add  ignored flags to the macho/main.cc file, and added these entries you can see in the diff. 

I've never worked on a linker before, and I am not sure if these need to be implemented, but as it stands, without these flags defined as valid flags, `sold` is not behaving as a drop-in replacement for AppleClang `ld`.   

This seems to fix it for the compiled Qt debug build I described in #53.
If this can't be merged without proper implementation, at least this is a start!